### PR TITLE
Make practice modal scrollable

### DIFF
--- a/mispronounciation/components/EnhancedPracticeModal.tsx
+++ b/mispronounciation/components/EnhancedPracticeModal.tsx
@@ -642,7 +642,7 @@ const styles = StyleSheet.create({
   modalContainer: {
     width: '90%',
     maxWidth: 400,
-    maxHeight: '80%',
+    maxHeight: '85%',
     backgroundColor: COLORS.white,
     borderRadius: 20,
     overflow: 'hidden',
@@ -651,6 +651,7 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.3,
     shadowRadius: 16,
     elevation: 8,
+    flexShrink: 1,
   },
   modalHeader: {
     flexDirection: 'row',
@@ -672,7 +673,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   modalContent: {
-    flex: 1,
+    flexGrow: 1,
   },
   wordSection: {
     padding: 20,

--- a/mispronounciation/components/EnhancedWordPracticeModal.tsx
+++ b/mispronounciation/components/EnhancedWordPracticeModal.tsx
@@ -811,16 +811,17 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
   },
   modalContainer: {
-    maxHeight: height * 0.95,
+    maxHeight: height * 0.90,
     borderTopLeftRadius: 32,
     borderTopRightRadius: 32,
     overflow: 'hidden',
-  },
-  scrollView: {
     flex: 1,
   },
-  scrollContent: {
+  scrollView: {
     flexGrow: 1,
+  },
+  scrollContent: {
+    paddingBottom: 20,
   },
   modalCard: {
     backgroundColor: COLORS.white,


### PR DESCRIPTION
Make practice modals scrollable to ensure all content is visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-56d51ca8-a5e4-428a-8447-f3ed0cafc8df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-56d51ca8-a5e4-428a-8447-f3ed0cafc8df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

